### PR TITLE
Añadido submódulo: mi-proyecto

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "repolocal525"]
+	path = repolocal525
+	url = https://github.com/GabyB73/mi-proyecto.git


### PR DESCRIPTION
Se ha añadido el repositorio 'mi-proyecto' como submódulo en la carpeta /repolocal525.
Esto permite incluir su contenido manteniéndolo como repositorio independiente.
